### PR TITLE
Add replicas option to nginx deployment

### DIFF
--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 {{ include "harbor.labels" . | indent 4 }}
     component: nginx
 spec:
-  replicas: 1
+  replicas: {{ .Values.nginx.replicas }}
   selector:
     matchLabels:
 {{ include "harbor.matchLabels" . | indent 6 }}


### PR DESCRIPTION
The `values.yaml` file containes a `nginx.replicas` options which is not
not used in the deployment file for the nginx