### PR TITLE
Adjust NGINX Configuration

### DIFF
--- a/templates/nginx/configmap-http.yaml
+++ b/templates/nginx/configmap-http.yaml
@@ -105,7 +105,7 @@ data:
           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
           
           # When setting up Harbor behind other proxy, such as an Nginx instance, remove the below line if the proxy already has similar settings.
-          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header X-Forwarded-Proto https;
           proxy_buffering off;
           proxy_request_buffering off;
         }


### PR DESCRIPTION
We are using Harbor behind an other proxy so we have to use
`proxy_set_header X-Forwarded-Proto https;` instead of
`proxy_set_header X-Forwarded-Proto $scheme;`